### PR TITLE
Fixed build so that it uses the `node_modules/` installed version of

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ Linux / OS X:
 
     export FB_APP_ID=12345
 
-Next, use Webpack to run the build:
+Next, to run the build:
 
-    webpack
+    npm run build
 
-(You can also use the `--watch` flag if you're making modifications and want to build as you do that.  You can use `-p` to minify the output bundles.)
+(You can also use the flags `-- --watch` if you're making modifications and want the build to run automatically when files change.  You can use `-- -p` to minify the output bundles.  Only one `--` flag is needed before other flags.)
 
 Finally, deploy everything in `/src` to your web server.
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "doc": "doc"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "node node_modules/webpack/bin/webpack.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
WebPack rather than relying on a globally installed version.  Added an
NPM script for `build` to make this easier.

Fixes #6 .